### PR TITLE
Parse table with booleans and numbers

### DIFF
--- a/stringify.lua
+++ b/stringify.lua
@@ -16,6 +16,11 @@ local subtable_start = '\29'
 -- used to delimit the end of a subtable
 local subtable_end = '\30'
 
+-- ASCII for boolean values
+local token_true = '\6' -- ASCII ACK "acknowledge"
+local token_false = '\21' -- ASCII NAK "negative acknowledge"
+
+
 function stringify_table(table)
   local str = ''
   for key, val in pairs(table) do
@@ -23,6 +28,8 @@ function stringify_table(table)
     local t = type(val)
     if t == 'table' then
       str = str..subtable_start..stringify_table(val)..subtable_end
+    elseif t == 'boolean' then
+      str = str..token_sep..(val and token_true or token_false)..token_sep
     else
       str = str..token_sep..val..token_sep
     end


### PR DESCRIPTION
This PR allows to convert an arbitrary table to a string without losing type information.
Booleans are codified with special ASCII values and numeric values are codified as a string.
When a string value needs to be decodified, it will try to decode as a number first. If it's not a numeric value then it will be treated as a string.

The only caveat is that strings that represent numeric values would be mistakenly assigned to numeric values